### PR TITLE
Run AMBER on a subset of reads

### DIFF
--- a/read-harvester/assets/custom.config
+++ b/read-harvester/assets/custom.config
@@ -35,11 +35,10 @@ params {
     // bwa-aln
     // Check "config/modules.config" for ancient DNA specific parameters
 
-    // samtools view
-
-    // AMBER
-
-    // MapDamage2
+    // samtools view subsample
+    // Number of reads to extract with samtools view --subsample
+    // For test dataset, set to 1000. For a standard dataset, set to 1000000. For refined analysis, set to 10000000.
+    subsample          = 1000
 
 }
 

--- a/read-harvester/assets/test-local.config
+++ b/read-harvester/assets/test-local.config
@@ -13,7 +13,7 @@ params {
     reference          = '/Users/verenakutschera/Documents/nobackup/projects/L_Dalen_2302/data/testdata/nf-core_eager/test-datasets/reference/Mammoth/Mammoth_MT_Krause.fasta'
 
     // Pipeline steps to be run (comma-separated list, full list: 'fastq_processing,mapping,processed_fastq_raw_bam_qc,bam_processing,processed_bam_qc,random_sampling_bam')
-    steps              = 'fastq_processing,mapping,processed_fastq_raw_bam_qc,bam_processing,processed_bam_qc,random_sampling_bam'
+    steps              = 'fastq_processing,mapping,processed_fastq_raw_bam_qc'
 
     // Pipeline outputs
     // Enter path to output directory
@@ -35,11 +35,10 @@ params {
     // bwa-aln
     // Check "config/modules.config" for ancient DNA specific parameters
 
-    // samtools view
-
-    // AMBER
-
-    // MapDamage2
+    // samtools view subsample
+    // Number of reads to extract with samtools view --subsample
+    // For test dataset, set to 1000. For a standard dataset, set to 1000000. For refined analysis, set to 10000000.
+    subsample          = 1000
 
 }
 

--- a/read-harvester/assets/test-rackham.config
+++ b/read-harvester/assets/test-rackham.config
@@ -35,11 +35,10 @@ params {
     // bwa-aln
     // Check "config/modules.config" for ancient DNA specific parameters
 
-    // samtools view
-
-    // AMBER
-
-    // MapDamage2
+    // samtools view subsample
+    // Number of reads to extract with samtools view --subsample
+    // For test dataset, set to 1000. For a standard dataset, set to 1000000. For refined analysis, set to 10000000.
+    subsample          = 1000
 
 }
 

--- a/read-harvester/configs/modules.config
+++ b/read-harvester/configs/modules.config
@@ -87,9 +87,16 @@ process {
 
     withName: 'SAMTOOLS_VIEW_SUBSAMPLE' {
         // Number of reads to extract with samtools view --subsample
-        ext.subsample = { "1000000" }
-        // Output format
-        ext.args      = { "--output-fmt bam" }
+        // For test dataset, set to 1000. For a standard dataset, set to 1000000. For refined analysis, set to 10000000.
+        ext.subsample = { "1000" }
+        // Additional arguments (optional)
+        ext.args      = { "" }
+        publishDir = [
+            path: { "${params.outdir}/data_qc/raw_bams/subsampled/" },
+            mode: params.publish_mode,
+            // Groovy ternary operator: https://groovy-lang.org/operators.html#_ternary_operator
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 
     withName: 'AMBER' {

--- a/read-harvester/configs/modules.config
+++ b/read-harvester/configs/modules.config
@@ -85,6 +85,13 @@ process {
         ]
     }
 
+    withName: 'SAMTOOLS_VIEW_SUBSAMPLE' {
+        // Number of reads to extract with samtools view --subsample
+        ext.subsample = { "1000000" }
+        // Output format
+        ext.args      = { "--output-fmt bam" }
+    }
+
     withName: 'AMBER' {
         publishDir = [
             path: { "${params.outdir}/data_qc/raw_bams/AMBER/" },

--- a/read-harvester/configs/modules.config
+++ b/read-harvester/configs/modules.config
@@ -86,9 +86,6 @@ process {
     }
 
     withName: 'SAMTOOLS_VIEW_SUBSAMPLE' {
-        // Number of reads to extract with samtools view --subsample
-        // For test dataset, set to 1000. For a standard dataset, set to 1000000. For refined analysis, set to 10000000.
-        ext.subsample = { "1000" }
         // Additional arguments (optional)
         ext.args      = { "" }
         publishDir = [

--- a/read-harvester/modules/local/samtools/faidx/main.nf
+++ b/read-harvester/modules/local/samtools/faidx/main.nf
@@ -4,8 +4,8 @@ process SAMTOOLS_FAIDX {
 
     conda "bioconda::samtools=1.18"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
-        'quay.io/biocontainers/samtools:1.18--h50ea8bc_1' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     path(fasta)

--- a/read-harvester/modules/local/samtools/merge/main.nf
+++ b/read-harvester/modules/local/samtools/merge/main.nf
@@ -4,8 +4,8 @@ process SAMTOOLS_MERGE {
 
     conda "bioconda::samtools=1.18"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
-        'quay.io/biocontainers/samtools:1.18--h50ea8bc_1' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input_files, stageAs: "?/*")

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -1,0 +1,72 @@
+process SAMTOOLS_VIEW_SUBSAMPLE {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::samtools=1.19.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
+
+    input:
+    tuple val(meta), path(bam)
+    path(fasta)
+
+    output:
+    tuple val(meta), path("${prefix}.${subsample}_reads.bam") , optional:true, emit: bam
+    tuple val(meta), path("${prefix}.${subsample}_reads.cram"), optional:true, emit: cram
+    path "versions.yml",                                                       emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def subsample = task.ext.subsample ?: '1'
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = fasta ? "--reference ${fasta}" : ""
+    def file_type = args.contains("--output-fmt sam") ? "sam" :
+                    args.contains("--output-fmt bam") ? "bam" :
+                    args.contains("--output-fmt cram") ? "cram" :
+                    input.getExtension()
+    """
+    total=`samtools view -c $bam` # total number of reads, not pairs (may include unmapped and duplicated multi-aligned reads)
+    frac=`awk -v s=$subsample -v t=$total "BEGIN {{print s/t}}"` # fraction of reads to keep
+
+    samtools \\
+        view \\
+        --threads ${task.cpus-1} \\
+        ${reference} \\
+        -s $frac \\
+        $args \\
+        -o ${prefix}.${subsample}_reads.${file_type} \\
+        $bam \\
+        $args2
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def file_type = args.contains("--output-fmt sam") ? "sam" :
+                    args.contains("--output-fmt bam") ? "bam" :
+                    args.contains("--output-fmt cram") ? "cram" :
+                    input.getExtension()
+    if ("$input" == "${prefix}.${file_type}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+
+    def index = args.contains("--write-index") ? "touch ${prefix}.csi" : ""
+
+    """
+    touch ${prefix}.${file_type}
+    ${index}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -34,7 +34,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
         ${reference} \\
         -s \$frac \\
         $args \\
-        -o ${prefix}.${subsample}_reads.bam \\
+        -o ${prefix}.approx_${subsample}_reads.bam \\
         $bam \\
         $args2
 
@@ -50,7 +50,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    touch ${prefix}.${subsample}_reads.bam
+    touch ${prefix}.approx_${subsample}_reads.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -12,8 +12,8 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     path(fasta)
 
     output:
-    tuple val(meta), path("${prefix}.${subsample}_reads.bam") , optional:true, emit: bam
-    path "versions.yml",                                                       emit: versions
+    tuple val(meta), path("*.bam") , emit: subsampled_bam
+    path "versions.yml",             emit: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -19,7 +19,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     task.ext.when == null || task.ext.when
 
     script:
-    def subsample = task.ext.subsample ?: '1'
+    def subsample = params.subsample ?: '1'
     def args = task.ext.args ?: ''
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -13,7 +13,6 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
 
     output:
     tuple val(meta), path("${prefix}.${subsample}_reads.bam") , optional:true, emit: bam
-    tuple val(meta), path("${prefix}.${subsample}_reads.cram"), optional:true, emit: cram
     path "versions.yml",                                                       emit: versions
 
     when:
@@ -25,10 +24,6 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference = fasta ? "--reference ${fasta}" : ""
-    def file_type = args.contains("--output-fmt sam") ? "sam" :
-                    args.contains("--output-fmt bam") ? "bam" :
-                    args.contains("--output-fmt cram") ? "cram" :
-                    input.getExtension()
     """
     total=\$(samtools view -c $bam) # total number of reads, not pairs (may include unmapped and duplicated multi-aligned reads)
     frac=\$(awk -v s=$subsample -v t=\$total "BEGIN {print s/t}") # fraction of reads to keep
@@ -39,7 +34,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
         ${reference} \\
         -s \$frac \\
         $args \\
-        -o ${prefix}.${subsample}_reads.${file_type} \\
+        -o ${prefix}.${subsample}_reads.bam \\
         $bam \\
         $args2
 
@@ -50,19 +45,12 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     """
 
     stub:
+    def subsample = task.ext.subsample ?: '1'
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def file_type = args.contains("--output-fmt sam") ? "sam" :
-                    args.contains("--output-fmt bam") ? "bam" :
-                    args.contains("--output-fmt cram") ? "cram" :
-                    input.getExtension()
-    if ("$input" == "${prefix}.${file_type}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
-
-    def index = args.contains("--write-index") ? "touch ${prefix}.csi" : ""
 
     """
-    touch ${prefix}.${file_type}
-    ${index}
+    touch ${prefix}.${subsample}_reads.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -5,7 +5,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     conda "bioconda::samtools=1.19.2"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
-        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
+        'quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(bam)

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -30,14 +30,14 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
                     args.contains("--output-fmt cram") ? "cram" :
                     input.getExtension()
     """
-    total=`samtools view -c $bam` # total number of reads, not pairs (may include unmapped and duplicated multi-aligned reads)
-    frac=`awk -v s=$subsample -v t=$total "BEGIN {{print s/t}}"` # fraction of reads to keep
+    total=\$(samtools view -c $bam) # total number of reads, not pairs (may include unmapped and duplicated multi-aligned reads)
+    frac=\$(awk -v s=$subsample -v t=\$total "BEGIN {print s/t}") # fraction of reads to keep
 
     samtools \\
         view \\
         --threads ${task.cpus-1} \\
         ${reference} \\
-        -s $frac \\
+        -s \$frac \\
         $args \\
         -o ${prefix}.${subsample}_reads.${file_type} \\
         $bam \\

--- a/read-harvester/modules/local/samtools/view_subsample/main.nf
+++ b/read-harvester/modules/local/samtools/view_subsample/main.nf
@@ -25,7 +25,7 @@ process SAMTOOLS_VIEW_SUBSAMPLE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference = fasta ? "--reference ${fasta}" : ""
     """
-    total=\$(samtools view -c $bam) # total number of reads, not pairs (may include unmapped and duplicated multi-aligned reads)
+    total=\$(samtools view -F 4 -q 1 -c $bam) # total number of reads, not pairs (excluding unmapped and duplicated multi-aligned reads)
     frac=\$(awk -v s=$subsample -v t=\$total "BEGIN {print s/t}") # fraction of reads to keep
 
     samtools \\

--- a/read-harvester/modules/nf-core/samtools/index/main.nf
+++ b/read-harvester/modules/nf-core/samtools/index/main.nf
@@ -4,8 +4,8 @@ process SAMTOOLS_INDEX {
 
     conda "bioconda::samtools=1.18"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.18--h50ea8bc_1' :
-        'quay.io/biocontainers/samtools:1.18--h50ea8bc_1' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'quay.io/biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input)

--- a/read-harvester/subworkflows/local/processed_fastq_raw_bam_qc/main.nf
+++ b/read-harvester/subworkflows/local/processed_fastq_raw_bam_qc/main.nf
@@ -3,6 +3,7 @@
 include { FASTQC as FASTQC_PROCESSED } from '../../../modules/nf-core/fastqc/main'
 include { MULTIQC as MULTIQC_FASTQ   } from '../../../modules/nf-core/multiqc/main'
 include { MAPDAMAGE2                 } from '../../../modules/local/mapdamage2/main'
+include { SAMTOOLS_VIEW_SUBSAMPLE    } from '../../../modules/local/samtools/view_subsample/main'
 include { CREATE_AMBER_SAMPLESHEET   } from '../../../modules/local/amber/create_amber_samplesheet'
 include { AMBER                      } from '../../../modules/local/amber/amber'
 include { QUALIMAP_BAMQC             } from '../../../modules/local/qualimap/bamqc/main'
@@ -41,7 +42,10 @@ workflow PROCESSED_FASTQ_RAW_BAM_QC {
     MAPDAMAGE2 ( bam, reference )
     ch_versions                              = ch_versions.mix(MAPDAMAGE2.out.versions)
 
-    CREATE_AMBER_SAMPLESHEET ( bam )
+    SAMTOOLS_VIEW_SUBSAMPLE ( bam, reference )
+    ch_versions                              = ch_versions.mix(SAMTOOLS_VIEW_SUBSAMPLE.out.versions)
+
+    CREATE_AMBER_SAMPLESHEET ( SAMTOOLS_VIEW_SUBSAMPLE.out.bam )
     ch_versions                              = ch_versions.mix(CREATE_AMBER_SAMPLESHEET.out.versions)
 
     AMBER ( 

--- a/read-harvester/subworkflows/local/processed_fastq_raw_bam_qc/main.nf
+++ b/read-harvester/subworkflows/local/processed_fastq_raw_bam_qc/main.nf
@@ -45,11 +45,11 @@ workflow PROCESSED_FASTQ_RAW_BAM_QC {
     SAMTOOLS_VIEW_SUBSAMPLE ( bam, reference )
     ch_versions                              = ch_versions.mix(SAMTOOLS_VIEW_SUBSAMPLE.out.versions)
 
-    CREATE_AMBER_SAMPLESHEET ( SAMTOOLS_VIEW_SUBSAMPLE.out.bam )
+    CREATE_AMBER_SAMPLESHEET ( SAMTOOLS_VIEW_SUBSAMPLE.out.subsampled_bam )
     ch_versions                              = ch_versions.mix(CREATE_AMBER_SAMPLESHEET.out.versions)
 
     AMBER ( 
-        bam.join( CREATE_AMBER_SAMPLESHEET.out.tsv )
+        SAMTOOLS_VIEW_SUBSAMPLE.out.subsampled_bam.join( CREATE_AMBER_SAMPLESHEET.out.tsv )
     )
     ch_versions                              = ch_versions.mix(AMBER.out.versions)
 
@@ -87,6 +87,7 @@ workflow PROCESSED_FASTQ_RAW_BAM_QC {
     mapdamage2_pctot_freq                    = MAPDAMAGE2.out.pctot_freq                    // channel: [ val(meta), path(pctot_freq) ]
     mapdamage2_pgtoa_freq                    = MAPDAMAGE2.out.pgtoa_freq                    // channel: [ val(meta), path(pgtoa_freq) ]
     mapdamage2_folder                        = MAPDAMAGE2.out.folder                        // channel: [ val(meta), path(folder) ]
+    subsampled_bam                           = SAMTOOLS_VIEW_SUBSAMPLE.out.subsampled_bam   // channel: [ val(meta), path(bam) ]
     amber_plot                               = AMBER.out.plot                               // channel: [ val(meta), path(plot) ]
     qualimap_results                         = QUALIMAP_BAMQC.out.results                   // channel: [ val(meta), path(results) ]
     multiqc_bam_report                       = MULTIQC_BAM.out.report.toList()              // channel: [ val(meta), path(report) ]


### PR DESCRIPTION
The number of reads is currently set to 1000 so that it works with the test dataset I'm using. The number can be adjusted in `custom.config` (or `test-local.config`, `test-rackham.config`).