### PR TITLE
Dev bilal readlenthreshold

### DIFF
--- a/read-harvester/bin/select_read_len_cutoff_amber.py
+++ b/read-harvester/bin/select_read_len_cutoff_amber.py
@@ -6,18 +6,24 @@ from statistics import mean
 """
 Author:		Bilal Sharif
 Contact: 	bilal.bioinfo@gmail.com
-Usage:      read_len_cutoff_amber.py <amber_output.txt>
+Usage:      read_len_cutoff_amber.py <amber_output.txt> <tolerance>
 """
 
-if len(sys.argv) != 2:
+if len(sys.argv) != 3:
     print("Usage: read_len_cutoff_amber.py <amber_output.txt>")
+    sys.exit(1)
+
+if float(sys.argv[2]) <= 0 or float(sys.argv[2]) >= 1:
+    print("Error: The tolerance value should be a float between 0 and 1")
     sys.exit(1)
 
 ### Setting up initial variables
 filein = sys.argv[1]
 read_lengths = []
 mismatch_rates = []
-tolerance = 1.05 ## tolerance 5% higher than the average mismatch rate
+tolerance = 1 + float(sys.argv[2])
+
+
 
 ### Read the mismatch rates from the input file
 data = False
@@ -53,7 +59,7 @@ cutoff_length = None
 warning = False
 for i in range(39, read_lengths[0]-1, -1):  # Walk backward from 39 to the smallest read length
     mismatch_rate = mismatch_rates[read_lengths.index(i)]
-    tolerance_threshold = avg_mismatch_rate * tolerance ## the tolerance threshold is 5% higher than the average mismatch rate
+    tolerance_threshold = avg_mismatch_rate * tolerance
     if mismatch_rate > tolerance_threshold:
         cutoff_length = i+1 ## the cutoff length is the read length of the last read with a mismatch rate below the tolerance threshold
         if not mismatch_rates[read_lengths.index(i-1)] > tolerance_threshold: ## if the mismatch rate of the previous read is not higher than the tolerance threshold, probably not necessary!!!!

--- a/read-harvester/configs/modules.config
+++ b/read-harvester/configs/modules.config
@@ -108,7 +108,7 @@ process {
         ]
     }
 
-    withName: 'READ_LEN_CUTOFF' {
+    withName: 'ESTIMATE_READ_LEN_CUTOFF' {
         publishDir = [
             path: { "${params.outdir}/data_qc/raw_bams/AMBER/" },
             mode: params.publish_mode,

--- a/read-harvester/main.nf
+++ b/read-harvester/main.nf
@@ -72,7 +72,7 @@ workflow {
         BAM_PROCESSING (
             params.reference ? file( params.reference, checkIfExists: true ) : [],
             MAPPING.out.bam,
-            RAW_BAM_QC.out.read_len_cutoff
+            RAW_BAM_QC.out.amber_txt
         )
     }
 

--- a/read-harvester/main.nf
+++ b/read-harvester/main.nf
@@ -71,7 +71,8 @@ workflow {
     if ( 'bam_processing' in workflow_steps ) {
         BAM_PROCESSING (
             params.reference ? file( params.reference, checkIfExists: true ) : [],
-            MAPPING.out.bam
+            MAPPING.out.bam,
+            RAW_BAM_QC.out.read_len_cutoff
         )
     }
 

--- a/read-harvester/modules/local/amber/estimate_read_len_cutoff.nf
+++ b/read-harvester/modules/local/amber/estimate_read_len_cutoff.nf
@@ -1,4 +1,6 @@
-process READ_LEN_CUTOFF {
+process ESTIMATE_READ_LEN_CUTOFF {
+    tag "$meta.id"
+    label 'process_single'
 
     conda "conda-forge::python=3.8.3"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -9,7 +11,7 @@ process READ_LEN_CUTOFF {
     tuple val(meta), path(amber_txt)
 
     output:
-    tuple val(meta), path("*read_len_cutoff.txt"), emit: read_len
+    tuple val(meta), path("*.txt")       , emit: read_len_cutoff
     path "versions.yml"                  , emit: versions
 
     when:
@@ -19,9 +21,13 @@ process READ_LEN_CUTOFF {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
+    // Define read lenght cutoff threshold 0.05 (5%) for paired-end and 0.01 (1%) for single-end
+    def cutoff_threshold = meta.single_end ? 0.01 : 0.05
+
     """
     select_read_len_cutoff_amber.py \\
-        $amber_txt 0.05 > ${prefix}_read_len_cutoff.txt
+        $amber_txt ${cutoff_threshold} > ${prefix}_read_len_cutoff_${cutoff_threshold}.txt
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/read-harvester/modules/local/amber/read_len_cutoff.nf
+++ b/read-harvester/modules/local/amber/read_len_cutoff.nf
@@ -21,7 +21,7 @@ process READ_LEN_CUTOFF {
 
     """
     select_read_len_cutoff_amber.py \\
-        $amber_txt > ${prefix}_read_len_cutoff.txt
+        $amber_txt 0.05 > ${prefix}_read_len_cutoff.txt
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python: \$(python --version | sed 's/Python //g')

--- a/read-harvester/modules/local/samtools/rm_short_reads/main.nf
+++ b/read-harvester/modules/local/samtools/rm_short_reads/main.nf
@@ -9,6 +9,7 @@ process RM_SHORT_READS {
 
     input:
     tuple val(meta), path(bam)
+    tuple val(meta), path(read_len)
 
     output:
     tuple val(meta), path("${prefix}.bam")  , emit: bam
@@ -20,12 +21,11 @@ process RM_SHORT_READS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    //#len=$(head -n 1 $read_len | awk -F ': ' '{print \$2}')
-
 
     """
+    len=\$(head -n 1 $read_len | awk -F ': ' '{print \$2}')
     samtools view -h --threads ${task.cpus-1} $bam | \\
-    awk 'length(\$10) >= 30 || \$1 ~ /^@/' | \\
+    awk -v len=\$len 'length(\$10) >= \$len || \$1 ~ /^@/' | \\
     samtools view -bh --threads ${task.cpus-1} -o ${prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml

--- a/read-harvester/modules/local/samtools/rm_short_reads/main.nf
+++ b/read-harvester/modules/local/samtools/rm_short_reads/main.nf
@@ -8,11 +8,10 @@ process RM_SHORT_READS {
         'community.wave.seqera.io/library/samtools:1.20--b5dfbd93de237464' }"
 
     input:
-    tuple val(meta), path(bam)
-    tuple val(meta), path(read_len)
+    tuple val(meta), path(bam), path(read_len)
 
     output:
-    tuple val(meta), path("${prefix}.bam")  , emit: bam
+    tuple val(meta), path("*.bam")          , emit: bam
     path "versions.yml"                     , emit: versions
 
     when:
@@ -24,9 +23,9 @@ process RM_SHORT_READS {
 
     """
     len=\$(head -n 1 $read_len | awk -F ': ' '{print \$2}')
-    samtools view -h --threads ${task.cpus-1} $bam | \\
-    awk -v len=\$len 'length(\$10) >= \$len || \$1 ~ /^@/' | \\
-    samtools view -bh --threads ${task.cpus-1} -o ${prefix}.bam
+    samtools view -h --threads ${task.cpus} $bam | \\
+    awk -v len=\$len 'length(\$10) >= len || \$1 ~ /^@/' | \\
+    samtools view -bh --threads ${task.cpus} -o ${prefix}-rl\${len}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/read-harvester/modules/local/samtools/rm_short_reads/main.nf
+++ b/read-harvester/modules/local/samtools/rm_short_reads/main.nf
@@ -1,0 +1,37 @@
+process RM_SHORT_READS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda "bioconda::samtools=1.20"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'oras://community.wave.seqera.io/library/samtools:1.20--ad906e74fde1812b' :
+        'community.wave.seqera.io/library/samtools:1.20--b5dfbd93de237464' }"
+
+    input:
+    tuple val(meta), path(bam)
+
+    output:
+    tuple val(meta), path("${prefix}.bam")  , emit: bam
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    //#len=$(head -n 1 $read_len | awk -F ': ' '{print \$2}')
+
+
+    """
+    samtools view -h --threads ${task.cpus-1} $bam | \\
+    awk 'length(\$10) >= 30 || \$1 ~ /^@/' | \\
+    samtools view -bh --threads ${task.cpus-1} -o ${prefix}.bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        awk: \$(echo \$(awk --version 2>&1) | sed 's/^.*awk //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/read-harvester/subworkflows/local/bam_processing/main.nf
+++ b/read-harvester/subworkflows/local/bam_processing/main.nf
@@ -3,6 +3,10 @@
 // Index the reference genome
 include { SAMTOOLS_FAIDX                                } from '../../../modules/local/samtools/faidx/main'
 
+// Read Length threshold
+include { RM_SHORT_READS                            } from '../../../modules/local/samtools/rm_short_reads/main'
+include { SAMTOOLS_INDEX as RM_SHORT_READS_INDEX    } from '../../../modules/nf-core/samtools/index/main'
+
 // Merge BAM files per library index
 include { SAMTOOLS_MERGE as SAMTOOLS_MERGE_LIB          } from '../../../modules/local/samtools/merge/main'
 include { SAMTOOLS_INDEX as SAMTOOLS_MERGE_LIB_INDEX    } from '../../../modules/nf-core/samtools/index/main'
@@ -35,6 +39,13 @@ workflow BAM_PROCESSING {
     // Index the reference genome
     SAMTOOLS_FAIDX ( reference )
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
+
+    // Remove short reads from BAM files
+    RM_SHORT_READS ( bam )
+    ch_versions = ch_versions.mix(RM_SHORT_READS.out.versions)
+
+    RM_SHORT_READS_INDEX ( RM_SHORT_READS.out.bam )
+    ch_versions = ch_versions.mix(RM_SHORT_READS_INDEX.out.versions)
 
     // Merge BAM files per library index
     ch_bam_lib_to_merge = bam.map {
@@ -81,10 +92,10 @@ workflow BAM_PROCESSING {
     ch_gatk_realignertargetcreator = SAMREMOVEDUP_SAMPLE.out.dedup.join(
         SAMREMOVEDUP_SAMPLE_INDEX.out.bai).groupTuple()
 
-    GATK_REALIGNERTARGETCREATOR ( 
-        ch_gatk_realignertargetcreator, 
-        reference, 
-        SAMTOOLS_FAIDX.out.fai, 
+    GATK_REALIGNERTARGETCREATOR (
+        ch_gatk_realignertargetcreator,
+        reference,
+        SAMTOOLS_FAIDX.out.fai,
         PICARD_CREATESEQUENCEDICTIONARY.out.reference_dict )
     ch_versions = ch_versions.mix(GATK_REALIGNERTARGETCREATOR.out.versions)
 
@@ -92,10 +103,10 @@ workflow BAM_PROCESSING {
         SAMREMOVEDUP_SAMPLE_INDEX.out.bai).join(
             GATK_REALIGNERTARGETCREATOR.out.intervals).groupTuple()
 
-    GATK_INDELREALIGNER ( 
-        ch_gatk_indelrealigner, 
-        reference, 
-        SAMTOOLS_FAIDX.out.fai, 
+    GATK_INDELREALIGNER (
+        ch_gatk_indelrealigner,
+        reference,
+        SAMTOOLS_FAIDX.out.fai,
         PICARD_CREATESEQUENCEDICTIONARY.out.reference_dict )
     ch_versions = ch_versions.mix(GATK_INDELREALIGNER.out.versions)
 

--- a/read-harvester/subworkflows/local/bam_processing/main.nf
+++ b/read-harvester/subworkflows/local/bam_processing/main.nf
@@ -4,8 +4,9 @@
 include { SAMTOOLS_FAIDX                                } from '../../../modules/local/samtools/faidx/main'
 
 // Read Length threshold
-include { RM_SHORT_READS                            } from '../../../modules/local/samtools/rm_short_reads/main'
-include { SAMTOOLS_INDEX as RM_SHORT_READS_INDEX    } from '../../../modules/nf-core/samtools/index/main'
+include { ESTIMATE_READ_LEN_CUTOFF                      } from '../../../modules/local/amber/estimate_read_len_cutoff'
+include { RM_SHORT_READS                                } from '../../../modules/local/samtools/rm_short_reads/main'
+include { SAMTOOLS_INDEX as RM_SHORT_READS_INDEX        } from '../../../modules/nf-core/samtools/index/main'
 
 // Merge BAM files per library index
 include { SAMTOOLS_MERGE as SAMTOOLS_MERGE_LIB          } from '../../../modules/local/samtools/merge/main'
@@ -32,7 +33,7 @@ workflow BAM_PROCESSING {
     take:
     reference
     bam
-    read_len_cutoff
+    amber_txt
 
     main:
     ch_versions = Channel.empty()
@@ -41,18 +42,31 @@ workflow BAM_PROCESSING {
     SAMTOOLS_FAIDX ( reference )
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
 
-    // Remove short reads from BAM files
-    RM_SHORT_READS ( bam, read_len_cutoff )
-    ch_versions = ch_versions.mix(RM_SHORT_READS.out.versions)
+    if (params.read_len_cutoff == "auto") {
 
-    RM_SHORT_READS_INDEX ( RM_SHORT_READS.out.bam )
-    ch_versions = ch_versions.mix(RM_SHORT_READS_INDEX.out.versions)
+        // Estimate read length cutoff
+        ESTIMATE_READ_LEN_CUTOFF ( amber_txt )
+        ch_versions = ch_versions.mix ( ESTIMATE_READ_LEN_CUTOFF.out.versions )
 
-    // Merge BAM files per library index
-    ch_bam_lib_to_merge = RM_SHORT_READS.out.bam.map {
-        meta, bam -> [ ['id':meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam ]
-        }
-        .groupTuple()
+        // Remove short reads from BAM files
+        ch_bam_read_len_cutoff = bam.join ( ESTIMATE_READ_LEN_CUTOFF.out.read_len_cutoff )
+        RM_SHORT_READS ( ch_bam_read_len_cutoff )
+        ch_versions = ch_versions.mix ( RM_SHORT_READS.out.versions )
+
+        RM_SHORT_READS_INDEX ( RM_SHORT_READS.out.bam )
+        ch_versions = ch_versions.mix ( RM_SHORT_READS_INDEX.out.versions )
+
+        // Prepare BAM files for merging
+        ch_bam_lib_to_merge = RM_SHORT_READS.out.bam.map { meta, bam ->
+            [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam]
+        }.groupTuple()
+
+    } else {
+        // Directly provide BAM channel for merging
+        ch_bam_lib_to_merge = bam.map { meta, bam ->
+            [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam]
+        }.groupTuple()
+    }
 
     SAMTOOLS_MERGE_LIB ( ch_bam_lib_to_merge, reference, SAMTOOLS_FAIDX.out.fai )
     ch_versions = ch_versions.mix(SAMTOOLS_MERGE_LIB.out.versions)
@@ -113,8 +127,8 @@ workflow BAM_PROCESSING {
 
     emit:
     fai                     = SAMTOOLS_FAIDX.out.fai                             // channel: path(index)
-    rm_short_reads_bam      = RM_SHORT_READS.out.bam                            // channel: [ val(meta), [ bam ] ]
-    rm_short_reads_index    = RM_SHORT_READS_INDEX.out.bai                       // channel: [ val(meta), [ bai ] ]
+    rm_short_reads_bam      = params.read_len_cutoff == "auto" ? RM_SHORT_READS.out.bam : Channel.empty()       // channel: [ val(meta), [ bam ] ]
+    rm_short_reads_index    = params.read_len_cutoff == "auto" ? RM_SHORT_READS_INDEX.out.bai : Channel.empty() // channel: [ val(meta), [ bai ] ]
     merged_bam_lib          = SAMTOOLS_MERGE_LIB.out.bam                         // channel: [ val(meta), [ bam ] ]
     merged_bam_lib_index    = SAMTOOLS_MERGE_LIB_INDEX.out.bai                   // channel: [ val(meta), [ bai ] ]
     dedup_lib               = SAMREMOVEDUP_LIB.out.dedup                         // channel: [ val(meta), [ bam ] ]

--- a/read-harvester/subworkflows/local/bam_processing/main.nf
+++ b/read-harvester/subworkflows/local/bam_processing/main.nf
@@ -32,6 +32,7 @@ workflow BAM_PROCESSING {
     take:
     reference
     bam
+    read_len_cutoff
 
     main:
     ch_versions = Channel.empty()
@@ -41,14 +42,14 @@ workflow BAM_PROCESSING {
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
 
     // Remove short reads from BAM files
-    RM_SHORT_READS ( bam )
+    RM_SHORT_READS ( bam, read_len_cutoff )
     ch_versions = ch_versions.mix(RM_SHORT_READS.out.versions)
 
     RM_SHORT_READS_INDEX ( RM_SHORT_READS.out.bam )
     ch_versions = ch_versions.mix(RM_SHORT_READS_INDEX.out.versions)
 
     // Merge BAM files per library index
-    ch_bam_lib_to_merge = bam.map {
+    ch_bam_lib_to_merge = RM_SHORT_READS.out.bam.map {
         meta, bam -> [ ['id':meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam ]
         }
         .groupTuple()
@@ -112,6 +113,8 @@ workflow BAM_PROCESSING {
 
     emit:
     fai                     = SAMTOOLS_FAIDX.out.fai                             // channel: path(index)
+    rm_short_reads_bam      = RM_SHORT_READS.out.bam                            // channel: [ val(meta), [ bam ] ]
+    rm_short_reads_index    = RM_SHORT_READS_INDEX.out.bai                       // channel: [ val(meta), [ bai ] ]
     merged_bam_lib          = SAMTOOLS_MERGE_LIB.out.bam                         // channel: [ val(meta), [ bam ] ]
     merged_bam_lib_index    = SAMTOOLS_MERGE_LIB_INDEX.out.bai                   // channel: [ val(meta), [ bai ] ]
     dedup_lib               = SAMREMOVEDUP_LIB.out.dedup                         // channel: [ val(meta), [ bam ] ]

--- a/read-harvester/subworkflows/local/raw_bam_qc/main.nf
+++ b/read-harvester/subworkflows/local/raw_bam_qc/main.nf
@@ -5,7 +5,6 @@ include { MAPDAMAGE2                 } from '../../../modules/local/mapdamage2/m
 include { SAMTOOLS_VIEW_SUBSAMPLE    } from '../../../modules/local/samtools/view_subsample/main'
 include { CREATE_AMBER_SAMPLESHEET   } from '../../../modules/local/amber/create_amber_samplesheet'
 include { AMBER                      } from '../../../modules/local/amber/amber'
-include { READ_LEN_CUTOFF            } from '../../../modules/local/amber/read_len_cutoff'
 include { MULTIQC as MULTIQC_BAM     } from '../../../modules/nf-core/multiqc/main'
 
 
@@ -52,12 +51,6 @@ workflow RAW_BAM_QC {
     )
     ch_versions                              = ch_versions.mix(AMBER.out.versions)
 
-    READ_LEN_CUTOFF (
-        AMBER.out.txt
-    )
-    ch_versions                              = ch_versions.mix(READ_LEN_CUTOFF.out.versions)
-
-
     emit:
     mapdamage2_fragmisincorporation_plot     = MAPDAMAGE2.out.fragmisincorporation_plot     // channel: [ val(meta), path(fragmisincorporation_plot) ]
     mapdamage2_length_plot                   = MAPDAMAGE2.out.length_plot                   // channel: [ val(meta), path(length_plot) ]
@@ -78,7 +71,6 @@ workflow RAW_BAM_QC {
     subsampled_bam                           = SAMTOOLS_VIEW_SUBSAMPLE.out.subsampled_bam   // channel: [ val(meta), path(bam) ]
     amber_plot                               = AMBER.out.plot                               // channel: [ val(meta), path(plot) ]
     amber_txt                                = AMBER.out.txt                                // channel: [ val(meta), path(txt) ]
-    read_len_cutoff                          = READ_LEN_CUTOFF.out.read_len                 // channel: [ val(meta), path(read_len) ]
     multiqc_bam_report                       = MULTIQC_BAM.out.report.toList()              // channel: [ val(meta), path(report) ]
     versions                                 = ch_versions                                  // channel: [ versions.yml ]
 }


### PR DESCRIPTION
if params.read_len_cutoff is set to auto, the pipeline will estimate the reads len cutoff from amber results using bilal scripts, link to gihub provided. the threshold is 0.05 for double stranded lib and 0.01 for single stranded library, this info is take from the samples sheet