### PR TITLE
fixed the select_read_len_cutoff_amber.py 

### DIFF
--- a/read-harvester/.github/test-eager_github.config
+++ b/read-harvester/.github/test-eager_github.config
@@ -26,10 +26,8 @@ params {
     // Tool specific parameters
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
-    readlength         = 20
-
-    // Optional: Set read_len_cutoff to "auto" if you want to estimate the lower read length threshold using script <link to github>.
-    read_len_cutoff = 'auto'
+    // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold using script <link to github>.
+    readlength         = '20'
 
     // bwa-index
     // 'is' for small reference genomes such as mitogenomes, 'bwtsw' for large reference genomes

--- a/read-harvester/.github/test-generode_github.config
+++ b/read-harvester/.github/test-generode_github.config
@@ -26,10 +26,8 @@ params {
     // Tool specific parameters
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
-    readlength         = 20
-
-    // Optional: Set read_len_cutoff to "auto" if you want to estimate the lower read length threshold using script <link to github>.
-    read_len_cutoff = 'auto'
+    // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold using script <link to github>.
+    readlength         = '20'
 
     // bwa-index
     // 'is' for small reference genomes such as mitogenomes, 'bwtsw' for large reference genomes

--- a/read-harvester/assets/custom.config
+++ b/read-harvester/assets/custom.config
@@ -26,10 +26,8 @@ params {
     // Tool specific parameters
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
-    readlength         = 20
-
-    // Optional: Set read_len_cutoff to "auto" if you want to estimate the lower read length threshold using script <link to github>.
-    read_len_cutoff = 'auto'
+    // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold using script <link to github>.
+    readlength         = '20'
 
     // bwa-index
     // 'is' for small reference genomes such as mitogenomes, 'bwtsw' for large reference genomes

--- a/read-harvester/bin/select_read_len_cutoff_amber.py
+++ b/read-harvester/bin/select_read_len_cutoff_amber.py
@@ -9,8 +9,9 @@ Contact: 	bilal.bioinfo@gmail.com
 Usage:      read_len_cutoff_amber.py <amber_output.txt> <tolerance>
 """
 
+### Checking the input arguments
 if len(sys.argv) != 3:
-    print("Usage: read_len_cutoff_amber.py <amber_output.txt>")
+    print("Usage: read_len_cutoff_amber.py <amber_output.txt> <tolerance>")
     sys.exit(1)
 
 if float(sys.argv[2]) <= 0 or float(sys.argv[2]) >= 1:
@@ -22,8 +23,6 @@ filein = sys.argv[1]
 read_lengths = []
 mismatch_rates = []
 tolerance = 1 + float(sys.argv[2])
-
-
 
 ### Read the mismatch rates from the input file
 data = False
@@ -47,34 +46,54 @@ if not data:
     print("Error: No mismatch rate data found in the input file. Please check the input file")
     sys.exit(1)
 
+###### Estimate the read length cutoff based on the average mismatch rate and tolerance threshold
+
+# If the shortest read length is >= 40, use it as the cutoff
+if read_lengths[0] >= 40:
+    print(f"Selected read length cutoff: {read_lengths[0]}")
+    print("The shortest read length is already >= 40. No walk-back step required.")
+    sys.exit(0)
 
 
+## Calculate the average mismatch rate using lengths between 40 and 60 if available
+filtered_mismatch_rates = [mismatch_rates[read_lengths.index(i)] for i in range(40, 61) if i in read_lengths]
 
-### Estimate the read length cutoff based on the average mismatch rate and tolerance threshold
+if not filtered_mismatch_rates:
+    print("Error: No mismatch rate data available for lengths between 40 and 60.")
+    sys.exit(1)
 
-## Calculate the average mismatch rate using the mismatch rates of reads with lengths between 40 and 60 bp
-avg_mismatch_rate = mean([mismatch_rates[read_lengths.index(i)] for i in range(40, 61)])
+avg_mismatch_rate = mean(filtered_mismatch_rates)
 
+
+### Walk back from 39 to the smallest read length
 cutoff_length = None
 warning = False
-for i in range(39, read_lengths[0]-1, -1):  # Walk backward from 39 to the smallest read length
+for i in range(39, read_lengths[0] - 1, -1):  # Walk backward from 39 to the smallest read length
+    if i not in read_lengths:
+        continue  # Skip missing lengths
     mismatch_rate = mismatch_rates[read_lengths.index(i)]
     tolerance_threshold = avg_mismatch_rate * tolerance
-    if mismatch_rate > tolerance_threshold:
-        cutoff_length = i+1 ## the cutoff length is the read length of the last read with a mismatch rate below the tolerance threshold
-        if not mismatch_rates[read_lengths.index(i-1)] > tolerance_threshold: ## if the mismatch rate of the previous read is not higher than the tolerance threshold, probably not necessary!!!!
+    if mismatch_rate > tolerance_threshold: ## only setting higher here as it works best with bwa aligner - not for bowtie2
+        cutoff_length = i + 1  # The cutoff length is the last read length with a mismatch rate below the tolerance threshold
+        if i - 1 in read_lengths and not mismatch_rates[read_lengths.index(i - 1)] > tolerance_threshold:
             warning = True
         break
     else:
-        ## updating the average mismatch rate and tolerance threshold
+        # Update the average mismatch rate and tolerance threshold
         avg_mismatch_rate = mean([avg_mismatch_rate, mismatch_rate])
 
-## Output the result
+# Output the result
 if cutoff_length:
     print(f"Selected read length cutoff: {cutoff_length}")
     if warning:
-        print(f"\nWARNING: The mismatch rate of read length {i} is higher than the tolerance threshold, but the mismatch rate of read length {i-1} is not. You might need to second look at the plot")
+        print(
+            f"\nWARNING: The mismatch rate of read length {i} is higher than the tolerance threshold, "
+            f"but the mismatch rate of read length {i-1} is not. You might wamt to visually inspect the amber plot."
+            )
 else:
-    print(f"No significant increase in mismatch rate was found until read length {read_lengths[0]-1}. Check if short reads are already filtered out")
-
+    print(
+        f"Selected read length cutoff: {read_lengths[0]}\n"
+        f"{read_lengths[0]} is also the shortest read in the file. "
+        f"Check if short reads are already filtered out because no incease in mismatch rate was observed."
+    )
 

--- a/read-harvester/configs/modules.config
+++ b/read-harvester/configs/modules.config
@@ -20,7 +20,10 @@ process {
 
     // FASTQ_PROCESSING
     withName: 'FASTP' {
-        ext.args   = { "-l ${params.readlength}" }
+        ext.args   = {
+            def readlength = (params.readlength == 'auto') ? 20 : params.readlength
+            "-l ${readlength}"
+        }
         publishDir = [
             path: { "${params.outdir}/processed_fastq/" },
             mode: params.publish_mode,

--- a/read-harvester/nextflow.config
+++ b/read-harvester/nextflow.config
@@ -40,10 +40,8 @@ params {
 
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
-    readlength         = 20
-
-    // Optional: Set read_len_cutoff to "auto" if you want to estimate the lower read length threshold using script <link to github>.
-    read_len_cutoff = 'auto'
+    // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold using script <link to github>.
+    readlength         = '20'
 
     // bwa-index
     // 'is' for small reference genomes such as mitogenomes, 'bwtsw' for large reference genomes

--- a/read-harvester/subworkflows/local/bam_processing/main.nf
+++ b/read-harvester/subworkflows/local/bam_processing/main.nf
@@ -56,7 +56,7 @@ workflow BAM_PROCESSING {
     ch_versions = ch_versions.mix ( SAMTOOLS_VIEW_MQ_INDEX.out.versions )
 
     // Filter for minimum read length estimated from AMBER output
-    if (params.read_len_cutoff == "auto") {
+    if (params.readlength == "auto") {
 
         // Estimate read length cutoff
         ESTIMATE_READ_LEN_CUTOFF ( amber_txt )
@@ -143,8 +143,8 @@ workflow BAM_PROCESSING {
     fai                     = SAMTOOLS_FAIDX.out.fai                                                            // channel: path(index)
     mq_filtered_bam         = SAMTOOLS_VIEW_MQ.out.bam                                                          // channel: [ val(meta), [ bam ] ]
     mq_filtered_index       = SAMTOOLS_VIEW_MQ_INDEX.out.bai                                                    // channel: [ val(meta), [ bai ] ]
-    rm_short_reads_bam      = params.read_len_cutoff == "auto" ? RM_SHORT_READS.out.bam : Channel.empty()       // channel: [ val(meta), [ bam ] ]
-    rm_short_reads_index    = params.read_len_cutoff == "auto" ? RM_SHORT_READS_INDEX.out.bai : Channel.empty() // channel: [ val(meta), [ bai ] ]
+    rm_short_reads_bam      = params.readlength == "auto" ? RM_SHORT_READS.out.bam : Channel.empty()            // channel: [ val(meta), [ bam ] ]
+    rm_short_reads_index    = params.readlength == "auto" ? RM_SHORT_READS_INDEX.out.bai : Channel.empty()      // channel: [ val(meta), [ bai ] ]
     merged_bam_lib          = SAMTOOLS_MERGE_LIB.out.bam                                                        // channel: [ val(meta), [ bam ] ]
     merged_bam_lib_index    = SAMTOOLS_MERGE_LIB_INDEX.out.bai                                                  // channel: [ val(meta), [ bai ] ]
     dedup_lib               = SAMREMOVEDUP_LIB.out.dedup                                                        // channel: [ val(meta), [ bam ] ]

--- a/read-harvester/subworkflows/local/processed_bam_qc/main.nf
+++ b/read-harvester/subworkflows/local/processed_bam_qc/main.nf
@@ -60,7 +60,7 @@ workflow PROCESSED_BAM_QC {
     ch_versions                              = ch_versions.mix(MULTIQC_MQ_FILTERED_BAM.out.versions)
 
     // rm_short_reads_bam
-    if (params.read_len_cutoff == "auto") {
+    if (params.readlength == "auto") {
 
         ch_flagstat_rm_short_reads_bam           = rm_short_reads_bam.join(rm_short_reads_bam_index)
 
@@ -187,7 +187,7 @@ workflow PROCESSED_BAM_QC {
     ch_versions                              = ch_versions.mix(SAMTOOLS_DEPTH_MEAN.out.versions)
 
     emit:
-    multiqc_rm_short_reads_report            = params.read_len_cutoff == "auto" ? MULTIQC_RM_SHORT_READS_BAM.out.report.toList() : Channel.empty() // channel: [ val(meta), path(report) ]
+    multiqc_rm_short_reads_report            = params.readlength == "auto" ? MULTIQC_RM_SHORT_READS_BAM.out.report.toList() : Channel.empty()      // channel: [ val(meta), path(report) ]
     multiqc_mq_filtered_report               = MULTIQC_MQ_FILTERED_BAM.out.report.toList()                                                         // channel: [ val(meta), path(report) ]
     multiqc_merged_bam_lib_report            = MULTIQC_MERGED_BAM_LIB.out.report.toList()                                                          // channel: [ val(meta), path(report) ]
     multiqc_dedup_lib_report                 = MULTIQC_DEDUP_LIB.out.report.toList()                                                               // channel: [ val(meta), path(report) ]


### PR DESCRIPTION
fixed the select_read_len_cutoff_amber.py so it does not throw error if some read lengths are missing, and if shortest read is >40, it choses that as cutoff and does not walk back