### PR TITLE
Version 0.1.2

### DIFF
--- a/assets/custom.config
+++ b/assets/custom.config
@@ -33,7 +33,7 @@ params {
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
     // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold <https://github.com/bilalbioinfo/scripts/blob/main/select_read_len_cuttoff.py>.
-    readlength             = '20'
+    readlength             = '30'
 
     // bwa-aln
     // Check "config/modules.config" for ancient DNA specific parameters

--- a/assets/custom.config
+++ b/assets/custom.config
@@ -50,13 +50,13 @@ params {
     // Set to 'true' to run the preseq lc_extrap analysis on all samples, which predicts the number of unique reads that would be observed as sequencing depth increases.
     preseq                 = 'false'
 
-    // Samtools depth
-    // '' to exclude positions with zero depth
-    // '-a' to output all positions (including those with zero depth)
-    positions              = ''
-    // Enter path to BED file with reference genome positions to include in depth calculation (e.g. repeat-mask BED file)
+    // Samtools depth of coverage
+    // Enter path to BED file with reference genome positions to include in depth of coverage calculation (e.g. repeat-mask BED file)
     // '' to run depth calculation on the entire reference genome
     intervals              = ''
+    // Set position parameter to '-a' calculates depth of coverage for all positions (including those with zero depth).
+    // Change to '' to exclude positions with zero depth.
+    positions              = '-a'
 
     // Check "config/modules.config" for additional tool-specific parameters
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -104,11 +104,17 @@ class RowChecker:
         """Assert that the library_id ID exists."""
         if len(row[self._library_id_col]) <= 0:
             raise AssertionError("An ID that is unique for each sequencing library_id is required.")
+        # Sanitize library_id IDs slightly.
+        row[self._library_id_col] = row[self._library_id_col].replace(" ", "-")
+        row[self._library_id_col] = row[self._library_id_col].replace("_", "-")
 
     def _validate_lane(self, row):
         """Assert that the lane number exists."""
         if len(row[self._lane_col]) <= 0:
             raise AssertionError("A lane number is required.")
+        # Sanitize lane numbers slightly.
+        row[self._lane_col] = row[self._lane_col].replace(" ", "-")
+        row[self._lane_col] = row[self._lane_col].replace("_", "-")
 
     def _validate_library_type(self, row):
         """Assert that the library type exists and it only contains one of the following values: 'single', 'double'."""

--- a/configs/dardel-test.config
+++ b/configs/dardel-test.config
@@ -50,8 +50,8 @@ process {
         time   = 6.h
     }
     withLabel: process_bwa_samse {
-        cpus   = 8
-        memory = 8.GB
+        cpus   = 16
+        memory = 16.GB
         time   = 1.h
     }
     withLabel: process_angsd {

--- a/configs/dardel-test.config
+++ b/configs/dardel-test.config
@@ -37,6 +37,30 @@ process {
     memory = 8.GB
     time   = 1.h
 
+
+    // Tools specfic configurations
+    withLabel: process_fastp {
+        cpus   = 8
+        memory = 8.GB
+        time   = 1.h
+    }
+    withLabel: process_bwa_aln {
+        cpus   = 16
+        memory = 16.GB
+        time   = 6.h
+    }
+    withLabel: process_bwa_samse {
+        cpus   = 8
+        memory = 8.GB
+        time   = 1.h
+    }
+    withLabel: process_angsd {
+        cpus   = 8
+        memory = 8.GB
+        time   = 1.d
+    }
+
+    // General process specifications
     withLabel: process_single {
         cpus   = 1
         memory = 1.GB

--- a/configs/dardel.config
+++ b/configs/dardel.config
@@ -49,8 +49,8 @@ process {
         time   = 4.d
     }
     withLabel: process_bwa_samse {
-        cpus   = 32
-        memory = 32.GB
+        cpus   = 64
+        memory = 56.GB
         time   = 6.h
     }
     withLabel: process_angsd {

--- a/configs/dardel.config
+++ b/configs/dardel.config
@@ -37,6 +37,29 @@ process {
     memory = 8.GB
     time   = 2.h
 
+    // Tools specfic configurations
+    withLabel: process_fastp {
+        cpus   = 16
+        memory = 14.GB
+        time   = 6.h
+    }
+    withLabel: process_bwa_aln {
+        cpus   = 64
+        memory = 56.GB
+        time   = 4.d
+    }
+    withLabel: process_bwa_samse {
+        cpus   = 32
+        memory = 32.GB
+        time   = 6.h
+    }
+    withLabel: process_angsd {
+        cpus   = 16
+        memory = 14.GB
+        time   = 4.d
+    }
+
+    // General process specifications
     withLabel: process_single {
         cpus   = 1
         memory = 1.GB
@@ -55,7 +78,7 @@ process {
     withLabel: process_high {
         cpus   = 64
         memory = 64.GB
-        time   = 3.d
+        time   = 1.d
     }
     withLabel: process_long {
         cpus   = 16
@@ -63,7 +86,9 @@ process {
         time   = 4.d
     }
     withLabel: process_high_memory {
+        cpus   = 64
         memory = 200.GB
+        time   = 6.h
     }
 
 }

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -321,7 +321,7 @@ process {
 
     withName: 'SAMTOOLS_DEPTH_MEAN' {
         // ${params.positions} from custom config file, empty string to exclude positions with zero depth, '-a' to include all positions
-        ext.args   = { "${params.positions} -q 30" }
+        ext.args   = { "${params.positions}" }
         publishDir = [
             path: { "${params.outdir}/data_qc/processed_bams/merged_bam_sample_dedup_depth/" },
             mode: params.publish_mode,

--- a/modules/local/angsd/dohaplocall/main.nf
+++ b/modules/local/angsd/dohaplocall/main.nf
@@ -1,6 +1,6 @@
 process ANGSD_DOHAPLOCALL {
     tag "$meta.id"
-    label 'process_long'
+    label 'process_angsd'
 
     conda "bioconda::angsd=0.939"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?

--- a/modules/local/angsd/haplotoplink/main.nf
+++ b/modules/local/angsd/haplotoplink/main.nf
@@ -1,6 +1,6 @@
 process ANGSD_HAPLOTOPLINK {
     tag "$meta.id"
-    label 'process_long'
+    label 'process_angsd'
 
     conda "bioconda::angsd=0.939"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?

--- a/modules/local/bwa/aln.nf
+++ b/modules/local/bwa/aln.nf
@@ -1,6 +1,6 @@
 process BWA_ALN {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_bwa_aln'
 
     conda "bioconda::bwa=0.7.18"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?

--- a/modules/local/bwa/aln.nf
+++ b/modules/local/bwa/aln.nf
@@ -21,9 +21,10 @@ process BWA_ALN {
     script:
     def args = task.ext.args ?: '' // ancient DNA parameters are added via args in the configs/modules.config file
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def reference = task.ext.reference ?: "${meta2.id}"
 
     """
-    INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
+    INDEX=`find -L ./ -name "${reference}.amb" | sed 's/\\.amb\$//'`
 
     bwa aln \\
         $args \\

--- a/modules/local/bwa/index.nf
+++ b/modules/local/bwa/index.nf
@@ -7,20 +7,21 @@ process BWA_INDEX {
         'oras://community.wave.seqera.io/library/bwa:0.7.18--4543b4091f454101' :
         'community.wave.seqera.io/library/bwa:0.7.18--324359fbc6e00dba' }"
 
-    storeDir "${params.reference.substring(0, params.reference.lastIndexOf('/'))}"
+    storeDir "${file(params.reference).parent}"
 
     input:
     tuple val(meta2), path(fasta)
 
     output:
-    tuple val(meta2), path("*.amb"), path("*.ann"), path("*.bwt"), path("*.pac"), path("*.sa")  , emit: index
-    path "versions.yml"                                                                         , emit: versions
+    tuple val(meta2), path("${meta2.id}.{amb,ann,bwt,pac,sa}", arity: '5')     , emit: index
+    path "versions.yml"                                                        , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
+
     """
     bwa \\
         index \\

--- a/modules/local/bwa/index.nf
+++ b/modules/local/bwa/index.nf
@@ -14,7 +14,6 @@ process BWA_INDEX {
 
     output:
     tuple val(meta2), path("${meta2.id}.{amb,ann,bwt,pac,sa}", arity: '5')     , emit: index
-    path "versions.yml"                                                        , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,9 +27,5 @@ process BWA_INDEX {
         $args \\
         ${fasta}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bwa: \$(echo \$(bwa 2>&1) | sed 's/^.*Version: //; s/Contact:.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/local/bwa/samse.nf
+++ b/modules/local/bwa/samse.nf
@@ -1,6 +1,6 @@
 process BWA_SAMSE {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_bwa_samse'
 
     conda "bioconda::bwa=0.7.18 bioconda::samtools=1.20"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?

--- a/modules/local/bwa/samse.nf
+++ b/modules/local/bwa/samse.nf
@@ -22,14 +22,15 @@ process BWA_SAMSE {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def read_group = meta.read_group ? "-r '${meta.read_group}'" : ""
+    def reference = task.ext.reference ?: "${meta2.id}"
 
     """
-    INDEX=`find -L ./ -name "*.amb" | sed 's/\\.amb\$//'`
+    INDEX=`find -L ./ -name "${reference}.amb" | sed 's/\\.amb\$//'`
 
     bwa samse \\
         $args \\
         $read_group \\
-        \$INDEX \\
+        \${INDEX} \\
         $sai \\
         $reads | samtools sort -@ ${task.cpus - 1} -O bam - > ${prefix}.bam
 

--- a/modules/local/fastp/pairedend.nf
+++ b/modules/local/fastp/pairedend.nf
@@ -1,7 +1,7 @@
 #! /usr/bin/env nextflow
 process FASTP {
     tag "$meta.id"
-    label 'process_high'
+    label 'process_fastp'
 
     conda "bioconda::fastp=0.24.0"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?

--- a/modules/local/fastp/pairedend.nf
+++ b/modules/local/fastp/pairedend.nf
@@ -1,13 +1,12 @@
 #! /usr/bin/env nextflow
-
 process FASTP {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::fastp=0.23.4"
+    conda "bioconda::fastp=0.24.0"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastp:0.23.4--h5f740d0_0' :
-        'quay.io/biocontainers/fastp:0.23.4--h5f740d0_0' }"
+        'oras://community.wave.seqera.io/library/fastp:0.24.0--0397de619771c7ae' :
+        'community.wave.seqera.io/library/fastp:0.24.0--62c97b06e8447690' }"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/local/samtools/depth_mean/main.nf
+++ b/modules/local/samtools/depth_mean/main.nf
@@ -35,7 +35,7 @@ process SAMTOOLS_DEPTH_MEAN {
         '{sum+=\$3} END { print sum/NR }' \\
         ${prefix}.tsv | \\
         awk \\
-        '{ printf "%.0f", \$1 }' \\
+        '{ printf "%.6f", \$1 }' \\
         > ${prefix}.dpstats.txt
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/stats_output/seq_stats.nf
+++ b/modules/local/stats_output/seq_stats.nf
@@ -37,13 +37,13 @@ process SEQ_STATS {
     ## collect stats
     id="${prefix}"
     raw_reads=\$(zcat ${reads} | wc -l | awk '{print \$1 / 4}')
-    merged_reads=\$(cat ${fastp_log} | grep "Read pairs merged" | awk -F ': ' '{print \$2}')
+    merged_reads=\$(cat ${fastp_log} | grep "Read pairs merged" | awk -F ': ' '{sum += \$2} END {print sum}')
     reference=\$(basename ${reference})
     mapping_program="bwa aln"
-    mapped_reads=\$(cat ${raw_bam_flagstat} | grep -m 1 "mapped (" | awk '{printf \$1 "\\t"}')
+    mapped_reads=\$(cat ${raw_bam_flagstat} | grep "primary mapped (" | awk '{sum += \$1} END {print sum}')
     mq_filter=${params.mq}
-    filtered_reads=\$(cat ${mq_filtered_bam_flagstat} | grep -m 1 "mapped (" | awk '{printf \$1 "\\t"}')
-    uniq_reads=\$(cat ${dedup_lib_flagstat} | grep -m 1 "mapped (" | awk '{printf \$1 "\\n"}')
+    filtered_reads=\$(cat ${mq_filtered_bam_flagstat} | grep "primary mapped (" | awk '{sum += \$1} END {print sum}')
+    uniq_reads=\$(cat ${dedup_lib_flagstat} | grep "primary mapped (" | awk '{sum += \$1} END {print sum}')
 
     samtools stats --threads ${task.cpus} ${dedup_lib} > ${prefix}-samtools-stats
     min_reads_len=\$(awk '/^RL/ {print \$2}' ${prefix}-samtools-stats | head -n 1)

--- a/modules/local/stats_output/seq_stats.nf
+++ b/modules/local/stats_output/seq_stats.nf
@@ -2,10 +2,10 @@ process SEQ_STATS {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::samtools=1.20"
+    conda "bioconda::samtools=1.21 conda-forge::gawk=5.3.1"
     container "${ workflow.containerEngine == 'apptainer' && !task.ext.apptainer_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/samtools:1.20--ad906e74fde1812b' :
-        'community.wave.seqera.io/library/samtools:1.20--b5dfbd93de237464' }"
+        'oras://community.wave.seqera.io/library/samtools_gawk:47334f042a11e64b' :
+        'community.wave.seqera.io/library/samtools_gawk:2f6ad5ac0a3fef78' }"
 
 
     input:
@@ -45,12 +45,11 @@ process SEQ_STATS {
     filtered_reads=\$(cat ${mq_filtered_bam_flagstat} | grep -m 1 "mapped (" | awk '{printf \$1 "\\t"}')
     uniq_reads=\$(cat ${dedup_lib_flagstat} | grep -m 1 "mapped (" | awk '{printf \$1 "\\n"}')
 
-    samtools stats --threads ${task.cpus} ${dedup_lib} > stats.txt
-    min_reads_len=\$(awk '/^RL/ {print \$2}' stats.txt | head -n 1)
-    max_reads_len=\$(awk '/^SN/ && /maximum length/ {print \$4}' stats.txt)
-    mean_reads_len=\$(awk '/^SN/ && /average length/ {print \$4}' stats.txt)
-    median_reads_len=\$(awk '/^RL/ {total+=\$3; lengths[\$2]=total} END \\
-    {median_pos=total/2; for (len in lengths) if (lengths[len]>=median_pos) {print len; break}}' stats.txt)
+    samtools stats --threads ${task.cpus} ${dedup_lib} > ${prefix}-samtools-stats
+    min_reads_len=\$(awk '/^RL/ {print \$2}' ${prefix}-samtools-stats | head -n 1)
+    max_reads_len=\$(awk '/^SN/ && /maximum length/ {print \$4}' ${prefix}-samtools-stats)
+    mean_reads_len=\$(awk '/^SN/ && /average length/ {print \$4}' ${prefix}-samtools-stats)
+    median_reads_len=\$(awk '/^RL/ {total+=\$3; lengths[\$2]=\$3} END {median=total/2; sum=0; for (len in lengths) {sum+=lengths[len]; if (sum>=median) {print len; break}}}' ${prefix}-samtools-stats)
 
     ## write stats
     printf "\$id\\t\$raw_reads\\t\$merged_reads\\t\$reference\\t\$mapping_program\\t\$mapped_reads\\t\$mq_filter\\t\$filtered_reads\\t\$uniq_reads\\
@@ -59,6 +58,7 @@ process SEQ_STATS {
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+        awk: \$(awk --version | head -n 1 | awk '{print \$1, \$2, \$3}')
     END_VERSIONS
     """
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,7 +44,7 @@ params {
     // Fastp
     // Enter minimum read length for a read to be kept after adapter trimming and read merging (default: 20)
     // Optional: set readlength to 'auto', if you want to estimate the lower read length threshold <https://github.com/bilalbioinfo/scripts/blob/main/select_read_len_cuttoff.py>.
-    readlength             = '20'
+    readlength             = '30'
 
     // bwa-aln
     // Check "config/modules.config" for ancient DNA specific parameters

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,13 +61,13 @@ params {
     // Set to 'true' to run the preseq lc_extrap analysis on all samples, which predicts the number of unique reads that would be observed as sequencing depth increases.
     preseq                 = 'false'
 
-    // Samtools depth
-    // '' to exclude positions with zero depth
-    // '-a' to output all positions (including those with zero depth)
-    positions              = ''
-    // Enter path to BED file with reference genome positions to include in depth calculation (e.g. repeat-mask BED file)
+    // Samtools depth of coverage
+    // Enter path to BED file with reference genome positions to include in depth of coverage calculation (e.g. repeat-mask BED file)
     // '' to run depth calculation on the entire reference genome
     intervals              = ''
+    // Set position parameter to '-a' calculates depth of coverage for all positions (including those with zero depth).
+    // Change to '' to exclude positions with zero depth.
+    positions              = '-a'
 
     // MultiQC
     multiqc_config         = null

--- a/subworkflows/local/bam_processing/main.nf
+++ b/subworkflows/local/bam_processing/main.nf
@@ -66,14 +66,14 @@ workflow BAM_PROCESSING {
         // Prepare BAM files for merging
         ch_bam_lib_to_merge = RM_SHORT_READS.out.bam.map { meta, bam ->
             // update only the 'id' field in meta, keep all other fields
-            [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam]
+            [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], bam]
         }.groupTuple()
 
     } else {
         // Directly provide BAM channel for merging
         ch_bam_lib_to_merge = SAMTOOLS_VIEW_MQ.out.bam.map { meta, bam ->
             // update only the 'id' field in meta, keep all other fields
-            [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], bam]
+            [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], bam]
         }.groupTuple()
     }
 
@@ -93,7 +93,7 @@ workflow BAM_PROCESSING {
     // Merge BAM files per sample
     ch_bam_sample_to_merge = SAMTOOLS_MERGE_LIB.out.bam.map { meta, bam ->
         // update only the 'id' field in meta, keep all other fields
-        [ meta + ['id': meta.id.split("_")[0]], bam]
+        [['id': meta.id.split("_")[0]], bam]
     }.groupTuple()
 
     SAMTOOLS_MERGE_SAMPLE ( ch_bam_sample_to_merge, ch_reference_fai )

--- a/subworkflows/local/mapping/main.nf
+++ b/subworkflows/local/mapping/main.nf
@@ -18,8 +18,8 @@ workflow MAPPING {
     SAMTOOLS_FAIDX ( reference )
     ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
 
+    // This will run only if the index is not already present
     BWA_INDEX ( reference )
-    ch_versions = ch_versions.mix(BWA_INDEX.out.versions)
 
     ch_reference_index = BWA_INDEX.out.index
         .map { id, files ->

--- a/subworkflows/local/mapping/main.nf
+++ b/subworkflows/local/mapping/main.nf
@@ -22,9 +22,9 @@ workflow MAPPING {
     ch_versions = ch_versions.mix(BWA_INDEX.out.versions)
 
     ch_reference_index = BWA_INDEX.out.index
-        .map { id, amb, ann, bwt, pac, sa ->
-            // Extracting the parent directory from one of the files
-            def parentDir = amb.getParent()
+        .map { id, files ->
+            // Extracting the parent directory from the first file in the list
+            def parentDir = files[0].getParent()
             return [id, parentDir] // Return necessary data
         }
         .collect()

--- a/subworkflows/local/stats_output/main.nf
+++ b/subworkflows/local/stats_output/main.nf
@@ -16,27 +16,31 @@ workflow STATS_OUTPUT {
 
     // Processing channel for merging
     ch_reads = reads.map { meta, data ->
-        [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], data[0]]
-    }
+        [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], data[0]]
+    }.groupTuple()
+
     ch_fastp_log = fastp_log.map { meta, data ->
-        [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], data ]
-    }
+        [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], data ]
+    }.groupTuple()
+
     ch_raw_bam_flagstat = raw_bam_flagstat.map { meta, data ->
-        [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], data ]
-    }
+        [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], data ]
+    }.groupTuple()
+
     ch_mq_filtered_bam_flagstat = mq_filtered_bam_flagstat.map { meta, data ->
-        [ meta + ['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1]], data ]
-    }
-    ch_dedup_lib_flagstat = dedup_lib_flagstat.map { meta, data ->
-        [ meta + ['id': meta.id], data ]
-    }
+        [['id': meta.id.split("_")[0] + "_" + meta.id.split("_")[1], 'library_type': meta.library_type, 'single_end': meta.single_end], data ]
+    }.groupTuple()
+
+    //ch_dedup_lib_flagstat = dedup_lib_flagstat.map { meta, data ->
+    //    [ meta + ['id': meta.id], data ]
+    //}
 
     // merging different channels
     ch_seq_stats = ch_reads
         .join(ch_fastp_log)
         .join(ch_raw_bam_flagstat)
         .join(ch_mq_filtered_bam_flagstat)
-        .join(ch_dedup_lib_flagstat)
+        .join(dedup_lib_flagstat)
         .join(dedup_lib)
 
     // run the SEQ_STATS process

--- a/subworkflows/local/stats_output/main.nf
+++ b/subworkflows/local/stats_output/main.nf
@@ -41,7 +41,7 @@ workflow STATS_OUTPUT {
 
     // run the SEQ_STATS process
     SEQ_STATS ( ch_seq_stats )
-
+    ch_versions = ch_versions.mix(SEQ_STATS.out.versions)
     // Concatenate all output files
     def all_stats_txt = SEQ_STATS.out.stats_txt
         .map { it[1] }


### PR DESCRIPTION
Bug Fix: Corrected median read length calculation.
Bug Fix: Ensured the correct reference index is selected when multiple indexes are present in the reference directory.
Bug Fix: Properly handle cases where the user includes "_" in the library ID and lane.
Bug Fix: Prevented unnecessary reference index generation if one already exists.
Bug Fix: Fixed merging of multiple FASTQ files per library and multiple libraries per sample.
Enhancement: Changed the default read length from 20 to 30.
Enhancement: Output depth of coverage as floating-point numbers
