### PR TITLE
Dev bilal add ref_prefix to bam filename

### DIFF
--- a/modules/local/bwa/aln.nf
+++ b/modules/local/bwa/aln.nf
@@ -22,6 +22,7 @@ process BWA_ALN {
     def args = task.ext.args ?: '' // ancient DNA parameters are added via args in the configs/modules.config file
     def prefix = task.ext.prefix ?: "${meta.id}"
     def reference = task.ext.reference ?: "${meta2.id}"
+    def ref_prefix = reference.replaceAll(/\.(fasta|fna|fa)$/, '')
 
     """
     INDEX=`find -L ./ -name "${reference}.amb" | sed 's/\\.amb\$//'`
@@ -29,7 +30,7 @@ process BWA_ALN {
     bwa aln \\
         $args \\
         -t $task.cpus \\
-        -f ${prefix}.sai \\
+        -f ${prefix}.${ref_prefix}.sai \\
         \${INDEX} \\
         ${reads}
 

--- a/modules/local/bwa/samse.nf
+++ b/modules/local/bwa/samse.nf
@@ -23,6 +23,7 @@ process BWA_SAMSE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def read_group = meta.read_group ? "-r '${meta.read_group}'" : ""
     def reference = task.ext.reference ?: "${meta2.id}"
+    def ref_prefix = reference.replaceAll(/\.(fasta|fna|fa)$/, '')
 
     """
     INDEX=`find -L ./ -name "${reference}.amb" | sed 's/\\.amb\$//'`
@@ -32,7 +33,7 @@ process BWA_SAMSE {
         $read_group \\
         \${INDEX} \\
         $sai \\
-        $reads | samtools sort -@ ${task.cpus - 1} -O bam - > ${prefix}.bam
+        $reads | samtools sort -@ ${task.cpus - 1} -O bam - > ${prefix}.${ref_prefix}.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/samremovedup/main.nf
+++ b/modules/local/samremovedup/main.nf
@@ -11,6 +11,7 @@ process SAMREMOVEDUP {
 
     input:
     tuple val(meta), path(bam)
+    tuple val(meta2), path(fasta), path(fai)
 
     output:
     tuple val(meta), path("*dedup.bam")                       , emit: dedup
@@ -21,6 +22,8 @@ process SAMREMOVEDUP {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def ref_prefix = task.ext.reference ?: "${meta2.id}".replaceAll(/\.(fasta|fna|fa)$/, '')
+
     """
     samtools view \\
         -@ ${task.cpus-1} \\
@@ -28,7 +31,7 @@ process SAMREMOVEDUP {
         samremovedup.py | \\
         samtools view \\
         -b \\
-        -o ${prefix}.dedup.bam
+        -o ${prefix}.${ref_prefix}.dedup.bam
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/samtools/merge/main.nf
+++ b/modules/local/samtools/merge/main.nf
@@ -12,8 +12,8 @@ process SAMTOOLS_MERGE {
     tuple val(meta2), path(fasta), path(fai)
 
     output:
-    tuple val(meta), path("${prefix}.bam") , optional:true, emit: bam
-    tuple val(meta), path("${prefix}.cram"), optional:true, emit: cram
+    tuple val(meta), path("${prefix}*.bam") , optional:true, emit: bam
+    tuple val(meta), path("${prefix}*.cram"), optional:true, emit: cram
     tuple val(meta), path("*.csi")         , optional:true, emit: csi
     tuple val(meta), path("*.crai")        , optional:true, emit: crai
     path  "versions.yml"                                  , emit: versions
@@ -27,13 +27,15 @@ process SAMTOOLS_MERGE {
     prefix   = task.ext.prefix ?: "${meta.id}"
     def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
     def reference = fasta ? "--reference ${fasta}" : ""
+    def ref_prefix = task.ext.reference ?: "${meta2.id}".replaceAll(/\.(fasta|fna|fa)$/, '')
+
     """
     samtools \\
         merge \\
         --threads ${task.cpus-1} \\
         $args \\
         ${reference} \\
-        ${prefix}.${file_type} \\
+        ${prefix}.${ref_prefix}.${file_type} \\
         $input_files
 
     cat <<-END_VERSIONS > versions.yml
@@ -47,9 +49,9 @@ process SAMTOOLS_MERGE {
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
     def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
     def index_type = file_type == "bam" ? "csi" : "crai"
-    def index = args.contains("--write-index") ? "touch ${prefix}.${index_type}" : ""
+    def index = args.contains("--write-index") ? "touch ${prefix}.${ref_prefix}.${index_type}" : ""
     """
-    touch ${prefix}.${file_type}
+    touch ${prefix}.${ref_prefix}.${file_type}
     ${index}
 
     cat <<-END_VERSIONS > versions.yml

--- a/subworkflows/local/bam_processing/main.nf
+++ b/subworkflows/local/bam_processing/main.nf
@@ -84,7 +84,7 @@ workflow BAM_PROCESSING {
     ch_versions = ch_versions.mix(SAMTOOLS_MERGE_LIB_INDEX.out.versions)
 
     // Remove duplicates from BAM files merged per library/PCR
-    SAMREMOVEDUP_LIB ( SAMTOOLS_MERGE_LIB.out.bam )
+    SAMREMOVEDUP_LIB ( SAMTOOLS_MERGE_LIB.out.bam, ch_reference_fai )
     ch_versions = ch_versions.mix(SAMREMOVEDUP_LIB.out.versions)
 
     SAMREMOVEDUP_LIB_INDEX ( SAMREMOVEDUP_LIB.out.dedup )
@@ -103,7 +103,7 @@ workflow BAM_PROCESSING {
     ch_versions = ch_versions.mix(SAMTOOLS_MERGE_SAMPLE_INDEX.out.versions)
 
     // Remove duplicates from BAM files merged per sample
-    SAMREMOVEDUP_SAMPLE ( SAMTOOLS_MERGE_SAMPLE.out.bam )
+    SAMREMOVEDUP_SAMPLE ( SAMTOOLS_MERGE_SAMPLE.out.bam, ch_reference_fai )
     ch_versions = ch_versions.mix(SAMREMOVEDUP_SAMPLE.out.versions)
 
     SAMREMOVEDUP_SAMPLE_INDEX ( SAMREMOVEDUP_SAMPLE.out.dedup )


### PR DESCRIPTION
I simply added the reference prefix to the output BAM filename. However, there might be a cleaner way to handle this by modifying the meta and including the reference prefix there. The problem is that we currently share the same meta between the FASTQ and BAM channels. In that case, should we create a separate meta for the BAM files? 